### PR TITLE
Warns at the possibility of a corrupted bup, with stream size of 0

### DIFF
--- a/punbup.py
+++ b/punbup.py
@@ -23,6 +23,8 @@ def extract(infile, dirname=None):
         ole = OleFileIO_PL.OleFileIO(infile)
         filelist = ole.listdir()
         for fname in filelist:
+            if not ole.get_size(fname[0]):
+                print 'Warning: The "%s" stream reports a size of 0. Possibly a corrupt bup.' % fname[0]
             data = ole.openstream(fname[0]).read()
             fp = open(os.path.join(dirname, fname[0]),'wb')
             fp.write(data)


### PR DESCRIPTION
It's not very common, but occasionally one of McAfee's bup files gets corrupted - in these cases, the pointers to the stream data are maxed out with  "0xFF" and the stream cannot be parsed properly. One commonality in these corrupt instances is that olefile can see a Details stream and parse it out; however it has no content.

Example of using punbup.py on a corrupted bup file:

dev@computer$ python punbup.py 7df51251e1e1a90.bup 
Successfully extracted all files to 7df51251e1e1a90.
dev@computer$ cd 7df51251e1e1a90
dev@computer:7df51251e1e1a90$ cat Details 
dev@computer$ 

I propose a modification to check the size of each stream olefile is able to identify. If the file size is 0, simply print a warning message. Aside from printing a warning message for an empty OLE stream, there is no change in behavior:

dev@computer$ python punbup.py 7df51251e1e1a90.bup 
Warning: The "Details" stream reports a size of 0. Possibly a corrupt bup.
Successfully extracted all files to 7df51251e1e1a90.
dev@computer$ cd 7df51251e1e1a90
dev@computer$ cat Details 
dev@computer$ 
